### PR TITLE
Prevent loss of all admins

### DIFF
--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -20,7 +20,7 @@ namespace TabloidMVC.Controllers
             _userProfileRepository = profileRepository;
             _userTypeRepository = userTypeRepository;
         }
-        // GET: UserProfileController
+        // GET: UserProfileController      Shows all active accounts
         [Authorize(Roles = "Admin")]
         public ActionResult Index()
         {
@@ -34,7 +34,7 @@ namespace TabloidMVC.Controllers
             return View(userProfiles);
         }
 
-        // GET: UserProfile/Deactive
+        // GET: UserProfile/Deactive    Shows all deactive accounts
         [Authorize(Roles = "Admin")]
         public ActionResult Deactive()
         {
@@ -109,6 +109,16 @@ namespace TabloidMVC.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Edit(int id, EditUserProfileViewModel vm)
         {
+            int amountOfAdmins = _userProfileRepository.GetAdminCount();
+
+            if (amountOfAdmins == 1 && vm.UserProfile.UserTypeId == 2)   // 1) Admin  2) Author
+            {
+                ModelState.AddModelError("UserProfile.UserTypeId", "Make someone else an admin before the User Profile can be changed.");
+                vm.UserTypes = _userTypeRepository.GetAll().OrderBy(x => x.Name).ToList();
+
+                return View(vm);
+            }
+            
             try
             {
                 _userProfileRepository.Update(vm.UserProfile);
@@ -140,6 +150,14 @@ namespace TabloidMVC.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Deactivate(int id, UserProfile userProfile)
         {
+            int amountOfAdmins = _userProfileRepository.GetAdminCount();
+
+            if (amountOfAdmins == 1 && userProfile.UserTypeId == 1)   // 1) Admin  2) Author
+            {
+                ModelState.AddModelError("UserTypeId", "Make someone else an admin before the User Profile can be changed.");
+                return View(userProfile);
+            }
+
             try
             {
                 _userProfileRepository.Deactivate(userProfile);

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -9,6 +9,7 @@ namespace TabloidMVC.Repositories
         List<UserProfile> GetAll();
         UserProfile GetByEmail(string email);
         UserProfile GetById(int id);
+        int GetAdminCount();
         void Deactivate (UserProfile profile);
         void Activate (UserProfile profile);
         void Update(UserProfile profile);

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -186,6 +186,27 @@ namespace TabloidMVC.Repositories
 
             }
         }
+        public int GetAdminCount()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT COUNT(uP.Id)
+                        FROM UserProfile uP
+                        LEFT JOIN UserType uT ON uT.Id = uP.UserTypeId
+                        WHERE uT.[Name] = 'Admin'
+                    ";
+
+                    int amountOfAdmins = (int)cmd.ExecuteScalar(); // Cast type of int
+                    
+                    return amountOfAdmins;
+                }
+            }
+        }
         public void Deactivate(UserProfile userProfile)
         {
             using (SqlConnection conn = Connection)

--- a/TabloidMVC/Views/UserProfile/Deactivate.cshtml
+++ b/TabloidMVC/Views/UserProfile/Deactivate.cshtml
@@ -46,7 +46,20 @@
     
     
     <form asp-action="Deactivate" method="post">
-        <input type="submit" value="Deactivate" class="btn btn-danger" /> |
-        <a asp-action="Index">Back to List</a>
+        <div class="form-group">
+            @Html.HiddenFor(m => m.FirstName)
+            @Html.HiddenFor(m => m.LastName)
+            @Html.HiddenFor(m => m.DisplayName)
+            @Html.HiddenFor(m => m.Email)
+            @Html.HiddenFor(m => m.CreateDateTime)
+            @Html.HiddenFor(m => m.ImageLocation)
+            @Html.HiddenFor(m => m.UserType.Id)
+            @Html.HiddenFor(m => m.UserType.Name)
+            @Html.HiddenFor(m => m.UserTypeId)
+        </div>
+        <div class="form-group">
+            <input type="submit" value="Deactivate" class="btn btn-danger" /> | <a asp-action="Index">Back to List</a>
+        </div>
+        <span asp-validation-for="UserTypeId" class="text-danger"></span>
     </form>
 </div>


### PR DESCRIPTION
Added a method to UserProfile repository to check how many admins there are at any given time.

When trying to edit a user's role or deactivate an account, prevented them from taking away the last admin.